### PR TITLE
Expanded store for Roster Groups to enable adding more meta data

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,12 @@
 {
   "main": {
+    "changed": [
+      "Made roster groups their own distinct entity allowing more data such as icons to be added to them.",
+      "You can now include multiple roster groups with the same name."
+    ],
+    "added": [
+      "Added an icon selection dropdown on the create and update screens for roster groups."
+    ],
     "bugfixes": [
       "Corrected the General VP calculation for the Domination scenario."
     ]

--- a/src/components/alerts/alert-types.tsx
+++ b/src/components/alerts/alert-types.tsx
@@ -22,7 +22,9 @@ export enum AlertTypes {
 
   UPDATE_GROUP_SUCCES = "UPDATE_GROUP_SUCCES",
   DISBAND_GROUP_SUCCES = "DISBAND_GROUP_SUCCES",
+  DISBAND_GROUP_FAILED = "DISBAND_GROUP_FAILED",
   DELETE_GROUP_SUCCES = "DELETE_GROUP_SUCCES",
+  DELETE_GROUP_FAILED = "DELETE_GROUP_FAILED",
 
   IMPORT_COLLECTION_COMPLETED = "IMPORT_COLLECTION_COMPLETED",
   IMPORT_COLLECTION_ERROR = "IMPORT_COLLECTION_ERROR",
@@ -207,6 +209,21 @@ export const alertMap = new Map<AlertTypes, AlertProps>([
     },
   ],
   [
+    AlertTypes.DELETE_GROUP_FAILED,
+    {
+      variant: "error",
+      content: (
+        <Fragment>
+          <b>Failed to delete</b>
+          <p>
+            The group could not be deleted, please refresh the page and try
+            again.
+          </p>
+        </Fragment>
+      ),
+    },
+  ],
+  [
     AlertTypes.DISBAND_GROUP_SUCCES,
     {
       variant: "success",
@@ -219,6 +236,21 @@ export const alertMap = new Map<AlertTypes, AlertProps>([
       options: {
         autoHideAfter: 2400,
       },
+    },
+  ],
+  [
+    AlertTypes.DISBAND_GROUP_FAILED,
+    {
+      variant: "error",
+      content: (
+        <Fragment>
+          <b>Failed to disbanded</b>
+          <p>
+            The group could not be disbanded, please refresh the page and try
+            again.
+          </p>
+        </Fragment>
+      ),
     },
   ],
   [

--- a/src/components/common/group-icon/GroupIcon.tsx
+++ b/src/components/common/group-icon/GroupIcon.tsx
@@ -1,0 +1,36 @@
+import { FaFolderOpen } from "react-icons/fa6";
+import { icons } from "./icons.tsx";
+
+const FallbackIcon = () => {
+  // const { mode } = useThemeContext();
+  // return (
+  //   <Avatar
+  //     alt="default faction logo"
+  //     src={fallbackLogo}
+  //     sx={{
+  //       width: 150,
+  //       height: 150,
+  //       mb: 2,
+  //       display: "inline-block",
+  //       backgroundColor: "transparent",
+  //       "& .MuiAvatar-img": {
+  //         filter: mode === "dark" ? "brightness(0) invert(1)" : "",
+  //       },
+  //     }}
+  //   />
+  // );
+  return <FaFolderOpen size={100} />;
+};
+
+export const GroupIcon = ({ icon }: { icon?: string }) => {
+  if (!icon) {
+    return <FallbackIcon />;
+  }
+
+  const iconComponent = icons[icon];
+  if (!iconComponent) {
+    return <FallbackIcon />;
+  } else {
+    return iconComponent;
+  }
+};

--- a/src/components/common/group-icon/GroupIconSelector.tsx
+++ b/src/components/common/group-icon/GroupIconSelector.tsx
@@ -1,0 +1,72 @@
+import { Autocomplete, ListItemIcon, TextField } from "@mui/material";
+import ListItem from "@mui/material/ListItem";
+import ListItemText from "@mui/material/ListItemText";
+import Typography from "@mui/material/Typography";
+import { JSX } from "react";
+import { factionLogos, gameIcons, numberIcons } from "./icons.tsx";
+
+export type Option = {
+  name: string;
+  icon: JSX.Element;
+  type: "Faction Icons" | "Custom Icons" | "Number Icons";
+};
+
+export const GroupIconSelector = ({
+  selectedIcon,
+  setSelectedIcon,
+}: {
+  selectedIcon: Option;
+  setSelectedIcon: (newValue: Option) => void;
+}) => {
+  const getIconSet = (
+    icons: Record<string, JSX.Element>,
+    type: Option["type"],
+  ): Option[] =>
+    Object.entries(icons)
+      .map(([name, icon]) => ({ name, icon, type }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+  const options: Option[] = [
+    ...getIconSet(factionLogos, "Faction Icons"),
+    ...getIconSet(gameIcons, "Custom Icons"),
+    ...getIconSet(numberIcons, "Number Icons"),
+  ];
+
+  return (
+    <Autocomplete
+      options={options}
+      getOptionLabel={(option) => option.name}
+      renderOption={(props, option) => {
+        return (
+          <ListItem {...props} key={option.name}>
+            <ListItemIcon>{option.icon}</ListItemIcon>
+            <ListItemText>{option.name}</ListItemText>
+          </ListItem>
+        );
+      }}
+      groupBy={(option) => option.type}
+      value={selectedIcon}
+      onChange={(_, newValue) => {
+        setSelectedIcon(newValue);
+      }}
+      filterSelectedOptions
+      blurOnSelect={true}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          placeholder="Type to filter..."
+          label="Group Icon (optional)"
+          helperText={
+            <Typography variant="body2" component="span">
+              Extra custom icons can be included on request. See{" "}
+              <a href="https://react-icons.github.io/react-icons/">
+                react-icons
+              </a>{" "}
+              for all potential options.
+            </Typography>
+          }
+        />
+      )}
+    />
+  );
+};

--- a/src/components/common/group-icon/icons.tsx
+++ b/src/components/common/group-icon/icons.tsx
@@ -1,0 +1,60 @@
+import { Fa1, Fa2, Fa3, Fa4, Fa5, Fa6, Fa7, Fa8, Fa9 } from "react-icons/fa6";
+import { GoArchive, GoTrophy } from "react-icons/go";
+import { HiOutlineThumbDown, HiOutlineThumbUp } from "react-icons/hi";
+import { HiBeaker, HiHeart, HiLightBulb } from "react-icons/hi2";
+import { TbCheese } from "react-icons/tb";
+import { FactionLogo } from "../images/FactionLogo.tsx";
+
+export const factionLogos = {
+  // Good factions
+  "Minas Tirith": <FactionLogo faction="Minas Tirith" />,
+  Rohan: <FactionLogo faction="Kingdom of Rohan" />,
+  Rivendell: <FactionLogo faction="Rivendell" />,
+  Lothlorien: <FactionLogo faction="Lothlorien" />,
+  Thranduil: <FactionLogo faction="Halls of Thranduil" />,
+  Arnor: <FactionLogo faction="Arnor" />,
+  Numenor: <FactionLogo faction="Numenor" />,
+  Rangers: <FactionLogo faction={"Arathorn's Stand"} />,
+  "The Iron Hills": <FactionLogo faction="The Iron Hills" />,
+  Fellowship: <FactionLogo faction="Breaking of the Fellowship" />,
+  Fangorn: <FactionLogo faction="Fangorn" />,
+  Eagles: <FactionLogo faction="The Eagles" />,
+  // Evil Factions
+  Mordor: <FactionLogo faction="Legions of Mordor" />,
+  Angmar: <FactionLogo faction="Shadows of Angmar" />,
+  Isengard: <FactionLogo faction="Muster of Isengard" />,
+  Moria: <FactionLogo faction="Depths of Moria" />,
+  Corsairs: <FactionLogo faction="Corsair Fleet" />,
+  Harad: <FactionLogo faction="Harad" />,
+  "Barad-dur": <FactionLogo faction="Barad-dur" />,
+  Necromancer: <FactionLogo faction="Rise of the Necromancer" />,
+};
+
+export const gameIcons = {
+  Experiment: <HiBeaker />,
+  Ideas: <HiLightBulb />,
+  Favorites: <HiHeart />,
+  Dislike: <HiOutlineThumbDown />,
+  Like: <HiOutlineThumbUp />,
+  Cheese: <TbCheese />,
+  Tournament: <GoTrophy />,
+  Archive: <GoArchive />,
+};
+
+export const numberIcons = {
+  "Number 1": <Fa1 />,
+  "Number 2": <Fa2 />,
+  "Number 3": <Fa3 />,
+  "Number 4": <Fa4 />,
+  "Number 5": <Fa5 />,
+  "Number 6": <Fa6 />,
+  "Number 7": <Fa7 />,
+  "Number 8": <Fa8 />,
+  "Number 9": <Fa9 />,
+};
+
+export const icons = {
+  ...factionLogos,
+  ...gameIcons,
+  ...numberIcons,
+};

--- a/src/components/modal/modals/ConfirmDeleteGroupModal.tsx
+++ b/src/components/modal/modals/ConfirmDeleteGroupModal.tsx
@@ -13,23 +13,26 @@ export const ConfirmDeleteGroupModal = () => {
     modalContext: { groupId, redirect },
     triggerAlert,
   } = useAppState();
-  const { deleteRoster, rosters } = useRosterBuildingState();
+  const { deleteGroup, groups, rosters } = useRosterBuildingState();
   const navigate = useNavigate();
-
-  const affectedRosters = rosters.filter((roster) => roster.group === groupId);
+  const { id, name } = groups.find((group) => group.slug === groupId) || {};
+  const affectedRosters = rosters.filter((roster) => roster.group === id);
 
   const [rosterGroupName, setRosterGroupName] = useState("");
 
   const handleConfirmDisband = (e) => {
     e.preventDefault();
 
-    affectedRosters.forEach((roster) => {
-      deleteRoster(roster);
-    });
-    if (redirect !== true) {
-      navigate("/rosters");
+    if (id) {
+      deleteGroup(id);
+      if (redirect === true) {
+        navigate("/rosters");
+      }
+      triggerAlert(AlertTypes.DELETE_GROUP_SUCCES);
+    } else {
+      triggerAlert(AlertTypes.DELETE_GROUP_FAILED);
     }
-    triggerAlert(AlertTypes.DELETE_GROUP_SUCCES);
+
     closeModal();
   };
 
@@ -54,7 +57,7 @@ export const ConfirmDeleteGroupModal = () => {
 
         <Typography>
           Confirm the group name to confirm: <br />
-          <b>{groupId}</b>
+          <b>{name}</b>
         </Typography>
         <TextField
           fullWidth
@@ -76,7 +79,7 @@ export const ConfirmDeleteGroupModal = () => {
           variant="contained"
           onClick={handleConfirmDisband}
           color="error"
-          disabled={groupId !== rosterGroupName}
+          disabled={name !== rosterGroupName}
           data-test-id="dialog--submit-button"
         >
           Delete group

--- a/src/components/modal/modals/ConfirmDisbandGroupModal.tsx
+++ b/src/components/modal/modals/ConfirmDisbandGroupModal.tsx
@@ -12,24 +12,25 @@ export const ConfirmDisbandGroupModal = () => {
     modalContext: { groupId, redirect },
     triggerAlert,
   } = useAppState();
-  const { updateRoster, rosters } = useRosterBuildingState();
+  const { disbandGroup, groups } = useRosterBuildingState();
+  const id = groups.find((group) => group.slug === groupId)?.id;
   const navigate = useNavigate();
 
   const handleConfirmDisband = (e) => {
     e.preventDefault();
 
-    rosters
-      .filter((roster) => roster.group === groupId)
-      .forEach((roster) => {
-        updateRoster({
-          ...roster,
-          group: null,
-        });
-      });
-    if (redirect !== true) {
-      navigate("/rosters");
+    console.log(id);
+
+    if (id) {
+      disbandGroup(id);
+      if (redirect === true) {
+        navigate("/rosters");
+      }
+      triggerAlert(AlertTypes.DISBAND_GROUP_SUCCES);
+    } else {
+      triggerAlert(AlertTypes.DISBAND_GROUP_FAILED);
     }
-    triggerAlert(AlertTypes.DISBAND_GROUP_SUCCES);
+
     closeModal();
   };
 

--- a/src/components/modal/modals/CreateNewRosterGroupModal.tsx
+++ b/src/components/modal/modals/CreateNewRosterGroupModal.tsx
@@ -2,17 +2,25 @@ import { Button, DialogActions, DialogContent, TextField } from "@mui/material";
 import { useState } from "react";
 import { useAppState } from "../../../state/app";
 import { useRosterBuildingState } from "../../../state/roster-building";
-import { CustomAlert } from "../../common/alert/CustomAlert.tsx";
+import { Roster } from "../../../types/roster.ts";
+import { slugify, withSuffix } from "../../../utils/string.ts";
+import {
+  GroupIconSelector,
+  Option as IconOption,
+} from "../../common/group-icon/GroupIconSelector.tsx";
 
 export const CreateNewRosterGroupModal = () => {
   const {
     closeModal,
     modalContext: { rosters = [] },
   } = useAppState();
-  const { updateRoster } = useRosterBuildingState();
+  const { createGroup } = useRosterBuildingState();
 
   const [rosterGroupName, setRosterGroupName] = useState("");
   const [rosterGroupNameValid, setRosterGroupNameValid] = useState(true);
+  const [rosterGroupIcon, setRosterGroupIcon] = useState<IconOption>({
+    name: "",
+  } as IconOption);
 
   function updateRosterName(name: string) {
     setRosterGroupName(name);
@@ -28,11 +36,11 @@ export const CreateNewRosterGroupModal = () => {
     setRosterGroupNameValid(nameValid);
 
     if (nameValid) {
-      rosters.forEach((roster) => {
-        updateRoster({
-          ...roster,
-          group: rosterGroupNameValue,
-        });
+      createGroup({
+        name: rosterGroupNameValue,
+        slug: withSuffix(slugify(rosterGroupNameValue)),
+        rosters: rosters.map((roster: Roster) => roster.id),
+        icon: rosterGroupIcon?.name,
       });
 
       closeModal();
@@ -42,11 +50,6 @@ export const CreateNewRosterGroupModal = () => {
   return (
     <>
       <DialogContent sx={{ display: "flex", gap: 2, flexDirection: "column" }}>
-        <CustomAlert severity="info" title="Create Group">
-          Choose a name for your roster group. Keep in mind that reusing an
-          existing name will add the rosters to that group instead!
-        </CustomAlert>
-
         <TextField
           fullWidth
           label="Group name"
@@ -56,6 +59,10 @@ export const CreateNewRosterGroupModal = () => {
           }
           value={rosterGroupName}
           onChange={(e) => updateRosterName(e.target.value)}
+        />
+        <GroupIconSelector
+          selectedIcon={rosterGroupIcon}
+          setSelectedIcon={setRosterGroupIcon}
         />
       </DialogContent>
       <DialogActions sx={{ display: "flex", gap: 2 }}>

--- a/src/components/modal/modals/CreateNewRosterModal.tsx
+++ b/src/components/modal/modals/CreateNewRosterModal.tsx
@@ -46,11 +46,13 @@ const armyLists = Object.values(data)
 
 export const CreateNewRosterModal = () => {
   const { closeModal } = useAppState();
-  const { createRoster, rosters } = useRosterBuildingState();
+  const { createRoster, rosters, groups } = useRosterBuildingState();
   const navigate = useNavigate();
   const { importJsonRoster } = useExport();
   const calculator = useCalculator();
-  const { groupId } = useParams();
+  const { groupId: groupSlug } = useParams();
+  const { id: groupId } =
+    groups.find((group) => group.slug === groupSlug) || {};
 
   const existingRosterIds = rosters.map(({ id }) => id);
 

--- a/src/layout/Navigation.tsx
+++ b/src/layout/Navigation.tsx
@@ -43,6 +43,7 @@ import { HiFire } from "react-icons/hi";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import logo from "../assets/images/logo.svg";
 import title from "../assets/images/title-v2024.png";
+import { icons as groupIcons } from "../components/common/group-icon/icons.tsx";
 import { FactionLogo } from "../components/common/images/FactionLogo.tsx";
 import { DrawerTypes } from "../components/drawer/drawers.tsx";
 import { ModalTypes } from "../components/modal/modals.tsx";
@@ -251,9 +252,10 @@ export const Navigation: FunctionComponent<PropsWithChildren> = ({
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
   const { rosterId } = useParams();
-  const { rosters } = useRosterBuildingState();
+  const { rosters, groups } = useRosterBuildingState();
   const { openSidebar, setCurrentModal } = useAppState();
   const { startNewGame, gameState } = useGameModeState();
+  const groupMap = Object.fromEntries(groups.map((group) => [group.id, group]));
 
   const groupedRosters = rosters.reduce(
     (groups, roster) => {
@@ -299,8 +301,8 @@ export const Navigation: FunctionComponent<PropsWithChildren> = ({
             action: () => {},
             active:
               location.pathname === `/rosters/${encodeURIComponent(group)}`,
-            icon: <FolderOutlined />,
-            label: group,
+            icon: groupIcons[groupMap[group]?.icon] || <FolderOutlined />,
+            label: groupMap[group]?.name || "Unknown name",
             children: [
               ...groupRosters
                 .sort((a, b) => a.name.localeCompare(b.name))

--- a/src/pages/builder/Roster.tsx
+++ b/src/pages/builder/Roster.tsx
@@ -33,7 +33,10 @@ import { useRosterWarnings } from "../../hooks/useRosterWarnings.ts";
 import { useScreenSize } from "../../hooks/useScreenSize.ts";
 import { useAppState } from "../../state/app";
 import { useUserPreferences } from "../../state/preference";
-import { useTemporalRosterBuildingState } from "../../state/roster-building";
+import {
+  useRosterBuildingState,
+  useTemporalRosterBuildingState,
+} from "../../state/roster-building";
 import { useThemeContext } from "../../theme/ThemeContext.tsx";
 import {
   MobileRosterInfoToolbar,
@@ -48,6 +51,8 @@ export const Roster = () => {
     useTemporalRosterBuildingState((state) => state);
   const { rosterId } = useParams();
   const { roster } = useRosterInformation();
+  const { groups } = useRosterBuildingState();
+  const group = roster.group && groups.find(({ id }) => roster.group === id);
   const { setCurrentModal } = useAppState();
   const displayMobileToolbar = useUserPreferences(
     ({ preferences }) => preferences.mobileRosterToolbar,
@@ -154,14 +159,14 @@ export const Roster = () => {
               >
                 My Rosters
               </Link>
-              {roster.group && (
+              {group && (
                 <Link
-                  to={`/rosters/${roster.group}`}
+                  to={`/rosters/${group.slug}`}
                   style={{
                     textDecoration: "none",
                   }}
                 >
-                  {roster.group}
+                  {group.name}
                 </Link>
               )}
               <Typography sx={{ color: "text.secondary" }}>

--- a/src/pages/rosters/components/RosterGroupCard.tsx
+++ b/src/pages/rosters/components/RosterGroupCard.tsx
@@ -1,25 +1,25 @@
-import Avatar from "@mui/material/Avatar";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { FunctionComponent } from "react";
-import fallbackLogo from "../../../assets/images/default.png";
+import { GroupIcon } from "../../../components/common/group-icon/GroupIcon.tsx";
 import { Link } from "../../../components/common/link/Link.tsx";
-import { useThemeContext } from "../../../theme/ThemeContext.tsx";
-import { Roster } from "../../../types/roster.ts";
 import { GroupOptionsPopoverMenu } from "./RosterGroupPopoverMenu.tsx";
 
 export type RosterSummaryCardProps = {
   name: string;
-  rosters: Roster[];
+  slug: string;
+  rosters: number;
+  icon?: string;
 };
 
 export const RosterGroupCard: FunctionComponent<RosterSummaryCardProps> = ({
   name,
+  slug,
   rosters,
+  icon,
 }) => {
-  const { mode } = useThemeContext();
   const cardStyle = {
     width: "34ch",
     left: "3ch",
@@ -33,10 +33,7 @@ export const RosterGroupCard: FunctionComponent<RosterSummaryCardProps> = ({
   const minStackSize = 3;
   const rotation = 1.5;
 
-  const stackSize = Math.min(
-    maxStackSize,
-    Math.max(minStackSize, rosters.length),
-  );
+  const stackSize = Math.min(maxStackSize, Math.max(minStackSize, rosters));
 
   const stack = new Array(stackSize)
     .fill(Number)
@@ -49,9 +46,9 @@ export const RosterGroupCard: FunctionComponent<RosterSummaryCardProps> = ({
 
   return (
     <Link
-      to={`/rosters/${name}`}
+      to={`/rosters/${slug}`}
       style={{ textDecoration: "none", color: "inherit" }}
-      data-test-id={"rosters--" + name + "--group-link"}
+      data-test-id={"rosters--" + slug + "--group-link"}
     >
       <Box sx={{ position: "relative", width: "40ch", height: "350px" }}>
         {stack.map((rot, i) => (
@@ -78,20 +75,16 @@ export const RosterGroupCard: FunctionComponent<RosterSummaryCardProps> = ({
             alignItems="center"
             textAlign="center"
           >
-            <Avatar
-              alt="default faction logo"
-              src={fallbackLogo}
+            <Box
               sx={{
-                width: 150,
-                height: 150,
-                mb: 2,
-                display: "inline-block",
-                backgroundColor: "transparent",
-                "& .MuiAvatar-img": {
-                  filter: mode === "dark" ? "brightness(0) invert(1)" : "",
+                "& .MuiAvatar-root, svg": {
+                  width: 100,
+                  height: 100,
                 },
               }}
-            />
+            >
+              <GroupIcon icon={icon} />
+            </Box>
             <Typography
               variant="h6"
               className="middle-earth"
@@ -114,7 +107,7 @@ export const RosterGroupCard: FunctionComponent<RosterSummaryCardProps> = ({
                 width: "240px", // Set a fixed width or max-width for overflow
               }}
             >
-              {rosters.length} Rosters
+              {rosters} Rosters
             </Typography>
           </Stack>
         </Card>
@@ -125,7 +118,7 @@ export const RosterGroupCard: FunctionComponent<RosterSummaryCardProps> = ({
             top: 24,
           }}
         >
-          <GroupOptionsPopoverMenu groupId={name} />
+          <GroupOptionsPopoverMenu groupId={slug} />
         </Box>
       </Box>
     </Link>

--- a/src/pages/rosters/components/RosterGroupPopoverMenu.tsx
+++ b/src/pages/rosters/components/RosterGroupPopoverMenu.tsx
@@ -64,7 +64,7 @@ export const GroupOptionsPopoverMenu = ({
           <ListItemIcon>
             <Edit fontSize="small" />
           </ListItemIcon>
-          <ListItemText> Rename group</ListItemText>
+          <ListItemText> Update group</ListItemText>
         </MenuItem>
         <MenuItem onClick={handleDisband}>
           <ListItemIcon>

--- a/src/state/roster-building/groups/index.ts
+++ b/src/state/roster-building/groups/index.ts
@@ -1,0 +1,86 @@
+import { v4 } from "uuid";
+import { Slice } from "../../Slice.ts";
+import { RosterBuildingState } from "../index.ts";
+
+export type RosterGroup = {
+  id: string;
+  name: string;
+  slug: string;
+  icon?: string;
+  rosters: string[];
+};
+
+type RosterGroupStateActions = {
+  createGroup: (group: Omit<RosterGroup, "id">) => string;
+  updateGroup: (id: string, update: Partial<Omit<RosterGroup, "id">>) => void;
+  disbandGroup: (id: RosterGroup["id"]) => void;
+  deleteGroup: (id: RosterGroup["id"]) => void;
+};
+
+export type RosterGroupState = {
+  groups: RosterGroup[];
+} & RosterGroupStateActions;
+
+export const initialBuilderState = {
+  groups: [],
+};
+
+export const groupSlice: Slice<RosterBuildingState, RosterGroupState> = (
+  set,
+  get,
+) => ({
+  ...initialBuilderState,
+
+  createGroup: (group) => {
+    const id = v4();
+    set(
+      ({ groups }) => ({
+        groups: [...groups, { ...group, id }],
+        rosters: get().rosters.map((roster) =>
+          group.rosters.includes(roster.id) ? { ...roster, group: id } : roster,
+        ),
+      }),
+      undefined,
+      "CREATE_ROSTER_GROUP",
+    );
+    return id;
+  },
+
+  updateGroup: (id, update) =>
+    set(
+      ({ groups }) => ({
+        groups: groups.map((group) =>
+          group.id === id ? { ...group, ...update } : group,
+        ),
+        rosters: get().rosters.map((roster) =>
+          update.rosters?.includes(roster.id)
+            ? { ...roster, group: id }
+            : roster,
+        ),
+      }),
+      undefined,
+      "UPDATE_ROSTER_GROUP",
+    ),
+
+  disbandGroup: (id) =>
+    set(
+      ({ groups }) => ({
+        groups: groups.filter((group) => group.id !== id),
+        rosters: get().rosters.map((roster) =>
+          roster.group === id ? { ...roster, group: null } : roster,
+        ),
+      }),
+      undefined,
+      "DISBAND_ROSTER_GROUP",
+    ),
+
+  deleteGroup: (id) =>
+    set(
+      ({ groups }) => ({
+        groups: groups.filter((group) => group.id !== id),
+        rosters: get().rosters.filter((roster) => roster.group !== id),
+      }),
+      undefined,
+      "DELETE_ROSTER_GROUP",
+    ),
+});

--- a/src/state/roster-building/index.ts
+++ b/src/state/roster-building/index.ts
@@ -4,9 +4,11 @@ import { create, StoreApi, useStore } from "zustand";
 
 import { createJSONStorage, devtools, persist } from "zustand/middleware";
 import { builderSlice, BuilderState } from "./builder-selection";
+import { groupSlice, RosterGroupState } from "./groups";
+import { migrations } from "./migrations.ts";
 import { rosterSlice, RosterState } from "./roster";
 
-export type RosterBuildingState = RosterState & BuilderState;
+export type RosterBuildingState = RosterState & BuilderState & RosterGroupState;
 
 export const useRosterBuildingState = create<
   RosterBuildingState,
@@ -22,6 +24,7 @@ export const useRosterBuildingState = create<
         (...args) => ({
           ...rosterSlice(...args),
           ...builderSlice(...args),
+          ...groupSlice(...args),
         }),
         {
           partialize: (state) => ({
@@ -35,9 +38,12 @@ export const useRosterBuildingState = create<
       {
         name: "mlb-rosters",
         storage: createJSONStorage(() => localStorage),
+        version: 1,
         partialize: (state) => ({
           rosters: state.rosters,
+          groups: state.groups,
         }),
+        migrate: (state, version) => migrations(state, version),
       },
     ),
   ),

--- a/src/state/roster-building/migrations.ts
+++ b/src/state/roster-building/migrations.ts
@@ -1,0 +1,68 @@
+import { v4 } from "uuid";
+import { slugify, withSuffix } from "../../utils/string.ts";
+import { BuilderState } from "./builder-selection";
+import { RosterGroupState } from "./groups";
+import { RosterBuildingState } from "./index.ts";
+import { RosterState } from "./roster";
+
+export const migrations = (
+  oldState: unknown,
+  version: number,
+): RosterBuildingState => {
+  console.debug(`Migrating persisted state from version ${version}`, {
+    oldState,
+  });
+
+  let migratedState = oldState;
+  if (version <= 0) {
+    console.debug("Migrating to v1");
+    migratedState = v1Migration(oldState as RosterState & BuilderState);
+    console.log("Migration v1;", { migratedState });
+  }
+
+  console.log("Migration completed", { newState: migratedState });
+  return migratedState as RosterBuildingState;
+};
+
+/**
+ * Migration #1 alters the way how groups work. Groups in v0 were a string as part of a roster.
+ * This was restrictive in a way that extension was impossible. Moving group data into an array of
+ * objects with all the data of said group (including a list of rosters part of that group) allows
+ * adding things like an Icon or a Slug.
+ *
+ * After this migration the roster.group field is filled with the ID of the group & a list of groups
+ * with id, name, slug and list of rosters is added.
+ */
+const v1Migration = (
+  state: RosterState & BuilderState,
+): RosterState & BuilderState & RosterGroupState => {
+  const grouped: Record<string, string[]> = state.rosters.reduce(
+    (acc, item) => {
+      if (!item.group) return acc;
+      if (!acc[item.group]) acc[item.group] = [];
+      acc[item.group].push(item.id);
+      return acc;
+    },
+    {},
+  );
+
+  const groups: RosterGroupState["groups"] = Object.entries(grouped).map(
+    ([name, rosters]) => ({
+      id: v4(),
+      name: name,
+      slug: withSuffix(slugify(name)),
+      rosters: rosters,
+    }),
+  );
+
+  const rosters = state.rosters.map((roster) =>
+    roster.group
+      ? {
+          ...roster,
+          group: groups.find((group) => group.name === roster.group)?.id,
+        }
+      : roster,
+  );
+
+  return { rosters, groups } as RosterState & BuilderState & RosterGroupState;
+};

--- a/src/state/roster-building/roster/index.ts
+++ b/src/state/roster-building/roster/index.ts
@@ -56,13 +56,21 @@ const initialState = {
   rosters: [],
 };
 
-export const rosterSlice: Slice<RosterBuildingState, RosterState> = (set) => ({
+export const rosterSlice: Slice<RosterBuildingState, RosterState> = (
+  set,
+  get,
+) => ({
   ...initialState,
 
   createRoster: (roster) => {
     set(
       (state) => ({
         rosters: [...state.rosters, roster],
+        groups: get().groups.map((group) =>
+          roster.group && roster.group === group.id
+            ? { ...group, rosters: [...group.rosters, roster.id] }
+            : group,
+        ),
       }),
       undefined,
       "CREATE_ROSTER",
@@ -85,6 +93,16 @@ export const rosterSlice: Slice<RosterBuildingState, RosterState> = (set) => ({
     set(
       (state) => ({
         rosters: state.rosters.filter(({ id }) => roster.id !== id),
+        groups: get().groups.map((group) =>
+          roster.group && roster.group === group.id
+            ? {
+                ...group,
+                rosters: group.rosters.filter(
+                  (rosterId) => rosterId !== roster.id,
+                ),
+              }
+            : group,
+        ),
       }),
       undefined,
       "DELETE_ROSTER",

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -36,7 +36,7 @@ export function isMovieQuote(str: string): boolean {
   return regex.test(str);
 }
 
-export function withSuffix(id: string, existingIds: string[]) {
+export function withSuffix(id: string, existingIds: string[] = []) {
   const hashedId = id + "-" + generateRandomHash(6);
   if (existingIds.includes(hashedId)) {
     return withSuffix(id, existingIds);


### PR DESCRIPTION
### !!! Running this branch locally updates your perstisted state !!!

---

Groups in previous versions for the builder were just a label on the Roster itself. With each roster having the same value for the group field being listed in that group. 

In this version (and any new version after this) groups will be their own entity. A group will look like the following;
```
{
  "id": "f2df0ca4-b6f9-46f7-b413-071ad8c952af"
  "name": "My Awesome Roster Group!",
  "slug": "my-awesome-roster-group-l7tswg",
  "rosters": [
    "roster-id-one",
    "roster-id-two"
  ],
  "icon": "Cheese",
}
```

The rosters itself will still utilize the group field, but should contain the group id. This allows us to update that group if the roster gets deleted.

--- 

Within the zustand persisted state config there is a function called `migrate` which checks if the version of the state is different from the version of the persisted state. *If this is the case* the function will get called allowing us to update and migrate the state to the wanted format. 

This function now looks at the roster groups that were present and creates a roster group entity for them while also updating the rosters group value to use the ID's. Functionally this means that the data is updated, visually this means nothing should change.

---

**Test scenarios I've used;**
- [x] Taking the localstorage value from the live app and manually overriding the localhost state. 
  - This alters the state back the how it was before the new group system and verifies if the migration script works properly
- [x] Creating a new Roster Group to verify new roster groups can be created without problem. With or without icons.
- [x] Creating multiple Roster Groups with the same name to verify this is now possible, checking that the slug is different each time.
- [x] Updating the name and/or icons on a group. Where a name update should redirect to the new created url
- [x] Disbanding a group from the /rosters correctly removes the group and retains all the rosters.
- [x] Disbanding a group from the group page itself should do the same AND redirect you to /rosters
- [x] Deleting a group should remove the group and the rosters
- [x] Deleting a group from the group page should do the same AND redirect you back to /rosters
- [x] Removing a roster from a group should... remove it from the group... AND display it again on /rosters
- [x] Deleting a roster which was in a group should update the amount of rosters in that group

**Extra verifications:**
- [x] Verify that icons are properly displayed, both in the roster page as well as the navigation
- [x] Verify that all the breadcrumbs display the roster name (not slug or id) and still work when clicking on them