### PR TITLE
Expanded automatic warband creation with mandatory heroes

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,8 @@
 {
   "main": {
+    "added": [
+      "Expanded the automatic warband creation function for mandatory heroes which already had a warning containing the phrase 'must always contain'."
+    ],
     "bugfixes": [
       "Corrected Duinhir to be a Hero of Fortitude in Defenders of the Pelennor.",
       "Corrected the Fate points shown on the The Undying's profile card."

--- a/src/hooks/new-roster/useMandatoryUnits.ts
+++ b/src/hooks/new-roster/useMandatoryUnits.ts
@@ -1,7 +1,8 @@
 import { v4 as randomUuid } from "uuid";
-import { mesbgData } from "../../assets/data.ts";
+import { mesbgData, warningRulesData } from "../../assets/data.ts";
 import { emptyWarband } from "../../state/roster-building/roster";
-import { Roster } from "../../types/roster.ts";
+import { Unit } from "../../types/mesbg-data.types.ts";
+import { Roster, SelectedUnit, Warband } from "../../types/roster.ts";
 import { useCalculator } from "../useCalculator.ts";
 import { useMandatoryGeneral } from "./useMandatoryGeneral.ts";
 
@@ -18,23 +19,57 @@ export const useMandatoryUnits = () => {
       return addMandatoryWoses(roster);
     }
 
-    return roster;
+    if (roster.armyList === "Battle of Bywater") {
+      return addMandatoryHobbits(roster);
+    }
+
+    return addCompulsoryHeroes(roster);
+  }
+
+  function addCompulsoryHeroes(roster: Roster): Roster {
+    const additionalWarbands = (warningRulesData[roster.armyList] || [])
+      .filter((rule) => rule.type === "compulsory")
+      .filter((rule) => rule.warning.includes("must always contain"))
+      .filter(
+        (rule) => !rule.warning.includes("who is always the Army's General"),
+      )
+      .flatMap((rule) => rule.dependencies)
+      .map((modelId) => mesbgData[modelId])
+      .filter((unit) => !!unit)
+      .filter((unit) => unit.unit_type.includes("Hero"))
+      .map((hero, i) => createWarband(i + roster.warbands.length, hero))
+      .map((warband) => calculator.recalculateWarband(warband));
+
+    return {
+      ...roster,
+      warbands: [...roster.warbands, ...additionalWarbands],
+    };
+  }
+
+  function addMandatoryHobbits(roster: Roster) {
+    const hobbits = [
+      "[battle-of-bywater] peregrin-took-captain-of-the-shire",
+      "[battle-of-bywater] frodo-of-the-nine-fingers",
+      "[battle-of-bywater] samwise-the-brave",
+    ];
+
+    const additionalWarbands = hobbits
+      .map((modelId) => mesbgData[modelId])
+      .map((hero, i) => createWarband(i + roster.warbands.length, hero))
+      .map((warband) => calculator.recalculateWarband(warband));
+
+    return {
+      ...roster,
+      warbands: [...roster.warbands, ...additionalWarbands],
+    };
   }
 
   function addMandatoryWoses(roster: Roster) {
     const ghan = mesbgData["[paths-of-the-druadan] ghan-buri-ghan"];
     const woses = mesbgData["[paths-of-the-druadan] woses-warrior"];
 
-    const wosesWarband = calculator.recalculateWarband({
-      id: randomUuid(),
-      hero: calculator.recalculatePointsForUnit({
-        ...ghan,
-        id: randomUuid(),
-        pointsPerUnit: ghan.base_points,
-        pointsTotal: ghan.base_points,
-        quantity: 1,
-      }),
-      units: [
+    const wosesWarband = calculator.recalculateWarband(
+      createWarband(2, ghan, [
         calculator.recalculatePointsForUnit({
           ...woses,
           id: randomUuid(),
@@ -42,16 +77,34 @@ export const useMandatoryUnits = () => {
           pointsTotal: woses.base_points * 12,
           quantity: 12,
         }),
-      ],
-      meta: {
-        ...emptyWarband.meta,
-        num: 2,
-      },
-    });
+      ]),
+    );
 
     return calculator.recalculateRoster({
       ...roster,
       warbands: [...roster.warbands, wosesWarband],
     });
+  }
+
+  function createWarband(
+    warbandNumber: number,
+    hero: Unit,
+    units: SelectedUnit[] = [],
+  ): Warband {
+    return {
+      id: randomUuid(),
+      hero: calculator.recalculatePointsForUnit({
+        ...hero,
+        id: randomUuid(),
+        pointsPerUnit: hero.base_points,
+        pointsTotal: hero.base_points,
+        quantity: 1,
+      }),
+      units: units,
+      meta: {
+        ...emptyWarband.meta,
+        num: warbandNumber,
+      },
+    };
   }
 };


### PR DESCRIPTION
Heey Alex, I've expanded the mandatory hero selection which now creates a warband for each mandatory hero in the list. I've also implemented a special case for the battle of bywater. 

I've tested it myself with Cirith Ungol and Battle of Fornost, feel free to merge or do some additional testen :) 