### PR TITLE
Fix typo on Gorbag profile

### DIFF
--- a/src/assets/data/profile_data.json
+++ b/src/assets/data/profile_data.json
@@ -9323,7 +9323,7 @@
         {
           "name": "Adaptive Fighter",
           "type": "Active",
-          "description": "If Gorbah wins a Duel Roll, he may choose an enemy model involved in the Combat, and that model must back away in a direction chosen by Gorbag. For example, they may be forced to back away over the edge of cliff, and take fall damage. Other models then back away as normal and Strikes are resolved."
+          "description": "If Gorbag wins a Duel Roll, he may choose an enemy model involved in the Combat, and that model must back away in a direction chosen by Gorbag. For example, they may be forced to back away over the edge of cliff, and take fall damage. Other models then back away as normal and Strikes are resolved."
         }
       ],
       "magic_powers": [],


### PR DESCRIPTION
Fixing a small typo on the Cirith Ungol army reference sheet.

<img width="301" height="143" alt="Capture d’écran, le 2026-01-26 à 21 59 09" src="https://github.com/user-attachments/assets/753dbd46-e984-4fea-979b-e116f59428fa" />

Also making Prettier happy as it was failing the pre-commit check/script 🤔 