### PR TITLE
Fixed match history date format

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -13,7 +13,8 @@
       "Fixed the missing Heroic Challenge on Aldrac's profile.",
       "Fixed the missing Unique keyword on Grinnah's profile card.",
       "Removed the horse option from the generic Ringwraith in the Army of the Great Eye.",
-      "Fixed a typo on for Gorbag's name on his profile."
+      "Fixed a typo on for Gorbag's name on his profile.",
+      "Fix the game date in the game results table inside the match history page (by Lionel Oto)."
     ],
     "security": [
       "Make the account service optional by validating env vars, allowing local development without shared credentials."

--- a/src/pages/match-history/components/GamesTable.tsx
+++ b/src/pages/match-history/components/GamesTable.tsx
@@ -86,8 +86,8 @@ const MatchRow: FunctionComponent<{ row: PastGame }> = ({ row }) => {
           {new Date(row.gameDate).toLocaleDateString("en-UK", {
             day: "2-digit",
             month: "long",
-            timeZone: "UTC",
             year: "numeric",
+            timeZone: "UTC",
           })}
         </TableCell>
         <TableCell>{row.armies}</TableCell>


### PR DESCRIPTION
# About

I was bugged because the dates in the match history are always displayed as the day before.

## Before

<img width="1492" height="751" alt="date-format" src="https://github.com/user-attachments/assets/b4289db2-86e5-4511-90a2-8c27ca5eccac" />

## After

Unfortunately, I don't have a screenshot with the fix as I currently have issues with my local env and I wanted to push the fix instead of delaying it further.

Let me know if you need anything else 😁 